### PR TITLE
Add encryption to chunk content so that it can only be read at the application layer

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,20 @@
+# OpenAI Configuration (Required)
+OPENAI_API_KEY=
+
+# Google Configuration (Required)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Anthropic Configuration (Optional)
+ANTHROPIC_API_KEY=
+
+# AWS Configuration (Optional)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Sidekick Configuration (Required)
+ENCRYPTION_KEY=
+ENCRYPTION_DETERMINISTIC_KEY=
+ENCRYPTION_KEY_DERIVATION_SALT=
+# TODO: Move this into per-environment Rails config.
+USE_LIVE_LLM=true

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -67,6 +67,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
+          ENCRYPTION_DETERMINISTIC_KEY: ${{ secrets.ENCRYPTION_DETERMINISTIC_KEY }}
+          ENCRYPTION_KEY_DERIVATION_SALT: ${{ secrets.ENCRYPTION_KEY_DERIVATION_SALT }}
           USE_LIVE_LLM: true
 
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb
+!/.env*.template
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -3,6 +3,8 @@
 class Chunk < ApplicationRecord
   belongs_to :document
 
+  encrypts :content
+
   validates :chunk_index, presence: true
   validates :content, presence: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,9 @@ module Chatting
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
     end
+
+    config.active_record.encryption.primary_key = ENV.fetch('ENCRYPTION_KEY', nil)
+    config.active_record.encryption.deterministic_key = ENV.fetch('ENCRYPTION_DETERMINISTIC_KEY', nil)
+    config.active_record.encryption.key_derivation_salt = ENV.fetch('ENCRYPTION_KEY_DERIVATION_SALT', nil)
   end
 end


### PR DESCRIPTION
Add encryption to chunk content so that it can only be read at the application layer

This requires setting a few new env vars, so I've also added a template for .env. To generate these values in your dev environment you can run:

`bin/rails db:encryption:init`
