### PR TITLE
Add a stable ID to documents so they can be tracked and changed across revisions

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -13,6 +13,8 @@ class Document < ApplicationRecord
 
   after_commit :chunk_attachment, on: %i[create update]
 
+  attribute :stable_id, :string, default: -> { SecureRandom.uuid_v7 }
+
   private
 
   def chunk_attachment

--- a/db/migrate/20240802124359_add_stable_id_to_document.rb
+++ b/db/migrate/20240802124359_add_stable_id_to_document.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddStableIdToDocument < ActiveRecord::Migration[7.1]
+  def up
+    add_column :documents, :stable_id, :string
+    Document.find_each do |document|
+      document.update!(stable_id: SecureRandom.uuid_v7)
+    end
+    add_check_constraint :documents, 'stable_id IS NOT NULL', name: 'check_stable_id_not_null', validate: false
+  end
+
+  def down
+    remove_column :documents, :stable_id
+    remove_check_constraint :documents, name: 'check_stable_id_not_null', if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_02_105243) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_02_124359) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -68,8 +68,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_105243) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "documentable_id"
+    t.string "stable_id"
     t.index ["documentable_id", "documentable_type"], name: "index_documents_on_documentable_id_and_type"
     t.index ["message_id"], name: "index_documents_on_message_id"
+    t.check_constraint "stable_id IS NOT NULL", name: "check_stable_id_not_null", validate: false
   end
 
   create_table "messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Document, type: :model do
     it { should have_many(:chunks).dependent(:destroy) }
   end
 
+  describe 'attributes' do
+    it 'sets a default value for stable_id' do
+      document = build(:document)
+      expect(document.stable_id).to be_present
+    end
+  end
+
   describe 'callbacks' do
     let(:document) { build(:document) }
 


### PR DESCRIPTION
Add a stable ID to documents so they can be tracked and changed across revisions
