### PR TITLE
Fix CSRF bug on authentication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :omniauthable, :database_authenticatable, omniauth_providers: %i[google_oauth2]
+  devise :database_authenticatable
 
   store_accessor :google_oauth, :credentials, prefix: true
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -3,7 +3,7 @@
     <div class="font-serif">
     </div>
 
-    <%= button_to user_google_oauth2_omniauth_authorize_path, data: { turbo: "false" },
+    <%= button_to auth_provider_path(provider: :google_oauth2), data: { turbo: "false" },
                   class: 'flex items-center p-2 border rounded gap-2 shadow-sm w-full justify-center hover:bg-slate-50 bg-white' do %>
       <%= image_tag 'google.png', class: 'h-4' %>
       Continue with Google

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,11 +310,4 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-
-  config.omniauth :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID', nil), ENV.fetch('GOOGLE_CLIENT_SECRET', nil), {
-    scope: %w[
-      https://www.googleapis.com/auth/userinfo.email
-      https://www.googleapis.com/auth/userinfo.profile
-    ].join(' ')
-  }
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,13 +2,20 @@
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID', nil), ENV.fetch('GOOGLE_CLIENT_SECRET', nil), {
+    scope: %w[
+      https://www.googleapis.com/auth/userinfo.email
+      https://www.googleapis.com/auth/userinfo.profile
+    ].join(' ')
+  }
+
+  provider :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID', nil), ENV.fetch('GOOGLE_CLIENT_SECRET', nil), {
     scope: [
       Ingestors::Google::Docs::REQUIRED_SCOPE
     ].join(' '),
     name: :google_with_google_drive,
     include_granted_scopes: true,
     prompt: 'consent',
-    callback_path: '/_/permissions/google/callback'
+    callback_path: '/_/permissions/google_with_google_drive/callback'
   }
 
   provider :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID', nil), ENV.fetch('GOOGLE_CLIENT_SECRET', nil), {
@@ -18,6 +25,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     name: :google_with_gmail,
     include_granted_scopes: true,
     prompt: 'consent',
-    callback_path: '/_/permissions/google/callback'
+    callback_path: '/_/permissions/google_with_gmail/callback'
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,14 +24,18 @@ Rails.application.routes.draw do
                sign_out: 'logout'
              },
              controllers: {
-               omniauth_callbacks: 'users/omniauth_callbacks',
                sessions: 'users/sessions'
              }
 
-  match '/auth/:provider', via: %i[post], as: :auth_provider, to: 'auth#create'
+  # Omniauth Callbacks
+  devise_scope :user do
+    get '/auth/google_oauth2/callback', to: 'users/omniauth_callbacks#google_oauth2', as: :omniauth_callback
+  end
 
+  match '/auth/:provider', via: %i[post], as: :auth_provider, to: 'auth#create'
   scope '/_/permissions' do
-    get '/google/callback', to: 'auth#handle_google_callback'
+    get '/google_with_google_drive/callback', to: 'auth#handle_google_callback'
+    get '/google_with_gmail/callback', to: 'auth#handle_google_callback'
   end
 
   # Defines the root path route ("/")


### PR DESCRIPTION

Since we had registered omniauth twice (once with devise and once via the Omniauth initializer), the middleware was running twice on each callback request. This was causing some issues where credentials wouldn't be assigned after sign in.

The unfortunate side effect of this PR is that a user will need to add additional callback URLs in their Google Oauth configuration. Have spent some time looking at this but can't find a way around at the moment.
