### PR TITLE
Change gmail to persist message metadata as an unencrypted JSON rather than an encrypted string.

### DIFF
--- a/app/models/gmail_message.rb
+++ b/app/models/gmail_message.rb
@@ -2,31 +2,33 @@
 
 class GmailMessage < ApplicationRecord
   has_one :document, as: :documentable, dependent: :destroy
-  encrypts :payload, :from, :to, :subject
+  encrypts :from, :to, :subject
 
-  def update_and_rechunk!(message, body:, headers:)
+  def update_and_rechunk!(message_metadata, body:, headers:)
     transaction do
-      update!(payload: message.to_json,
-              from: headers['from'],
-              to: headers['to'],
-              subject: headers['subject'],
-              received_at: Time.at(message.internal_date / 1000)) # Convert milliseconds to seconds
+      update!(
+        message_metadata_payload: message_metadata,
+        from: headers[:from],
+        to: headers[:to],
+        subject: headers[:subject],
+        received_at: Time.at(message_metadata[:internal_date] / 1000) # Convert milliseconds to seconds
+      )
       document.rechunk!(body)
     end
   end
 
-  def self.create_from_user_message!(message, body:, headers:)
+  def self.create_from_user_message!(message_metadata, body:, headers:)
     transaction do
       gmail_message = create!(
-        payload: message.to_json,
-        from: headers['from'],
-        to: headers['to'],
-        subject: headers['subject'],
-        received_at: Time.at(message.internal_date / 1000) # Convert milliseconds to seconds
+        message_metadata_payload: message_metadata,
+        from: headers[:from],
+        to: headers[:to],
+        subject: headers[:subject],
+        received_at: Time.at(message_metadata[:internal_date] / 1000) # Convert milliseconds to seconds
       )
 
       document = gmail_message.create_document!(
-        stable_id: message.id,
+        stable_id: message_metadata[:id],
         documentable: gmail_message
       )
 

--- a/db/migrate/20240813094132_fix_gmail_payload.rb
+++ b/db/migrate/20240813094132_fix_gmail_payload.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class FixGmailPayload < ActiveRecord::Migration[7.1]
+  def change
+    add_column :gmail_messages, :message_metadata_payload, :jsonb
+
+    safety_assured do
+      remove_column :gmail_messages, :payload
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_12_133453) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_13_094132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -110,13 +110,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_133453) do
   end
 
   create_table "gmail_messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "payload"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "from"
     t.string "to"
     t.string "subject"
     t.datetime "received_at"
+    t.jsonb "message_metadata_payload"
   end
 
   create_table "google_drive_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/gmail_message_factory.rb
+++ b/spec/factories/gmail_message_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :gmail_message do
-    payload do
+    message_metadata_payload do
       {
         id: '17b8f1d1b1b1b1b1',
         threadId: '17b8f1d1b1b1b1b1',

--- a/spec/lib/ingestors/google/gmail_spec.rb
+++ b/spec/lib/ingestors/google/gmail_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Ingestors::Google::Gmail do
     allow(Signet::OAuth2::Client).to receive(:new).and_return(mock_oauth_client)
     allow(mock_oauth_client).to receive(:fetch_access_token!)
     allow(mock_client).to receive(:authorization).and_return(mock_oauth_client)
+    allow(mock_message).to receive(:to_h).and_return({ id: 'message_id', internal_date: Time.current.to_i * 1000, raw: '123123' })
   end
 
   describe '#ingest' do
@@ -55,7 +56,7 @@ RSpec.describe Ingestors::Google::Gmail do
       let!(:gmail_message) { create(:gmail_message, document: existing_document) }
 
       it 'updates the existing document' do
-        expect { ingestor.ingest }.to change { gmail_message.reload.payload }.to(mock_message.to_json)
+        expect { ingestor.ingest }.to change { gmail_message.reload.message_metadata_payload }.to(mock_message.to_h.except(:raw).stringify_keys)
       end
     end
 
@@ -65,7 +66,7 @@ RSpec.describe Ingestors::Google::Gmail do
       let(:mock_message) { instance_double(Google::Apis::GmailV1::Message, id: 'message_id', internal_date: 2.days.ago.to_i) }
 
       it 'does not update the existing document' do
-        expect { ingestor.ingest }.not_to(change { gmail_message.reload.payload })
+        expect { ingestor.ingest }.not_to(change { gmail_message.reload.message_metadata_payload })
       end
     end
 


### PR DESCRIPTION

Purposefully stripped out the critical pieces of sensitive data from the hash so we only store metadata rather than any actual content.
