### PR TITLE
Dropzone allow multiple files by default

### DIFF
--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -46,7 +46,7 @@ export default class extends Controller {
 
     get url() { return this.inputTarget.getAttribute("data-direct-upload-url") }
 
-    get maxFiles() { return this.data.get("maxFiles") || 1 }
+    get maxFiles() { return this.data.get("maxFiles") || null }
 
     get maxFileSize() { return this.data.get("maxFileSize") || 256 }
 


### PR DESCRIPTION
Fixes: https://linear.app/contextco/issue/CTX-508/[sidekick]-multi-upload-does-not-work-for-more-than-one-file-upload

<img width="1507" alt="Screenshot 2024-08-13 at 11 00 34" src="https://github.com/user-attachments/assets/953ddbbc-4f92-4e7a-8731-fbed3413f2e7">
