### PR TITLE
Parse and strip HTML from gmail messages

### DIFF
--- a/app/lib/ingestors/google/gmail.rb
+++ b/app/lib/ingestors/google/gmail.rb
@@ -51,7 +51,7 @@ class Ingestors::Google::Gmail
     return if document&.last_sync_at.present? && document.last_sync_at.to_i > response.internal_date / 1000
 
     headers = extract_headers(response&.payload&.headers)
-    body = response&.payload&.body&.data
+    body = Nokogiri::HTML(response&.payload&.body&.data).text
     return if body.blank?
 
     Document.transaction do


### PR DESCRIPTION

It's not so useful to chunk up HTML tags from these messages.
