### PR TITLE
Key the sync log by the integration key rather than the class name

### DIFF
--- a/app/jobs/concerns/loggable_job.rb
+++ b/app/jobs/concerns/loggable_job.rb
@@ -27,6 +27,7 @@ module LoggableJob
   end
 
   def log
-    @log ||= SyncLog.start(task_name: self.class.name, user: arguments.first)
+    integration = Integration.from_backfill_job(self.class)
+    @log ||= SyncLog.start(task_name: integration.key, user: arguments.first)
   end
 end

--- a/app/lib/integration.rb
+++ b/app/lib/integration.rb
@@ -25,5 +25,12 @@ class Integration
 
       new(**info.merge(key:))
     end
+
+    def from_backfill_job(job)
+      info = INFO.find { |_, v| v[:backfill_job] == job }
+      raise ArgumentError, "Unknown backfill job: #{job}" unless info
+
+      new(**info.second.merge(key: info.first))
+    end
   end
 end

--- a/spec/jobs/sync/gmail_messages_job_spec.rb
+++ b/spec/jobs/sync/gmail_messages_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Sync::GmailMessagesJob, type: :job do
     allow(gmail_ingestor).to receive(:ingest)
 
     perform_enqueued_jobs do
-      expect(SyncLog).to receive(:start).with(task_name: 'Sync::GmailMessagesJob', user:).and_return(sync_log)
+      expect(SyncLog).to receive(:start).with(task_name: :gmail, user:).and_return(sync_log)
       expect(sync_log).to receive(:mark_as_completed!)
       Sync::GmailMessagesJob.perform_later(user)
     end
@@ -42,7 +42,7 @@ RSpec.describe Sync::GmailMessagesJob, type: :job do
       Sync::GmailMessagesJob.perform_now(user)
     end.to raise_error(StandardError, 'Something went wrong')
 
-    expect(SyncLog).to have_received(:start).with(task_name: 'Sync::GmailMessagesJob', user:)
+    expect(SyncLog).to have_received(:start).with(task_name: :gmail, user:)
     expect(sync_log).to have_received(:mark_as_completed!)
   end
 

--- a/spec/jobs/sync/google_docs_job_spec.rb
+++ b/spec/jobs/sync/google_docs_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Sync::GoogleDocsJob, type: :job do
 
   it 'starts and ends logging' do
     perform_enqueued_jobs do
-      expect(SyncLog).to receive(:start).with(task_name: 'Sync::GoogleDocsJob', user:).and_return(double('SyncLog', mark_as_completed!: true))
+      expect(SyncLog).to receive(:start).with(task_name: :google_docs, user:).and_return(double('SyncLog', mark_as_completed!: true))
       Sync::GoogleDocsJob.perform_later(user)
     end
   end


### PR DESCRIPTION

This will make it less brittle to the job implementation.
