### PR TITLE
Add a server-only launch option

### DIFF
--- a/bin/server-only
+++ b/bin/server-only
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+./bin/rails db:prepare
+
+exec foreman start -f Procfile.monolith "$@"


### PR DESCRIPTION
Allows running the image without the postgres+redis dependencies so you can define them externally if you wish.