### PR TITLE
Significantly speed up the document query in 2 ways:

### DIFF
--- a/app/views/chats/_chat.html.erb
+++ b/app/views/chats/_chat.html.erb
@@ -17,7 +17,7 @@
       </div>
     </div>
     <div class="flex flex-col gap-4 overflow-y-auto py-4 flex-1 items-center" data-chat-target="scrollContainer" data-scroll-to-bottom-target>
-      <div class="items max-w-prose w-full flex flex-col gap-4">
+      <div class="items max-w-3xl w-full flex flex-col gap-4">
         <% @chat.messages.each do |message| %>
           <% if message.role == 'assistant' %>
             <div class="flex gap-4 last:pb-8 w-full">
@@ -39,7 +39,7 @@
                 <div class="text-sm text-slate-700 flex gap-4">
                   <%= turbo_stream_from message %>
                   <div id="<%= dom_id(message) %>" class="leading-relaxed message-content min-h-4 px-2 py-1 rounded-md bg-stone-200 flex flex-col gap-1">
-                    <%== markdown_to_html(message.content) %>
+                    <div class="whitespace-pre-wrap"><%= message.content %></div>
                     <% if message.documents.present? %>
                       <div class="flex gap-2">
                         <% message.documents.each do |document| %>
@@ -53,7 +53,7 @@
                   </div>
                 </div>
               </div>
-              <div class="size-6 items-center h-full flex shrink-0 overflow-hidden"><%= image_tag current_user.profile_picture_url, class: 'rounded-full overflow-hidden', referrerpolicy: 'no-referrer' %></div>
+              <div class="size-6 items-start mt-1 h-full flex shrink-0 overflow-hidden"><%= image_tag current_user.profile_picture_url, class: 'rounded-full overflow-hidden', referrerpolicy: 'no-referrer' %></div>
             </div>
           <% end %>
         <% end %>

--- a/db/migrate/20240815093548_add_embedding_index.rb
+++ b/db/migrate/20240815093548_add_embedding_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddEmbeddingIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :chunks, :embedding, using: :hnsw, opclass: :vector_l2_ops, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_13_122228) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_15_093548) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_13_122228) do
     t.vector "embedding", limit: 1536
     t.index ["document_id", "chunk_index"], name: "index_chunks_on_document_id_and_chunk_index", unique: true
     t.index ["document_id"], name: "index_chunks_on_document_id"
+    t.index ["embedding"], name: "index_chunks_on_embedding", opclass: :vector_l2_ops, using: :hnsw
   end
 
   create_table "console1984_commands", force: :cascade do |t|


### PR DESCRIPTION

Add an index to the embedding search.
Restrict the total number of chunks we retrieve to the 50 most relevant.
