### PR TITLE
Fix sync logs query to use task name rather than the class name

### DIFF
--- a/app/lib/ingestors/google/docs.rb
+++ b/app/lib/ingestors/google/docs.rb
@@ -49,7 +49,7 @@ class Ingestors::Google::Docs
   end
 
   def search_query
-    last_sync_at = user.sync_logs.where(task_name: 'Sync::GoogleDocsJob')&.maximum(:started_at)
+    last_sync_at = user.sync_logs.where(task_name: Integration.from_key!(:google_docs).key)&.maximum(:started_at)
 
     if last_sync_at.present?
       "mimeType = 'application/vnd.google-apps.document' and modifiedTime > '#{last_sync_at.strftime('%Y-%m-%dT%H:%M:%S')}'"

--- a/app/lib/ingestors/google/gmail.rb
+++ b/app/lib/ingestors/google/gmail.rb
@@ -75,7 +75,7 @@ class Ingestors::Google::Gmail
   end
 
   def search_query
-    latest_sync_at = user.sync_logs.where(task_name: 'Sync::GmailMessagesJob')&.maximum(:started_at)
+    latest_sync_at = user.sync_logs.where(task_name: Integration.from_key!(:gmail).key)&.maximum(:started_at)
     if latest_sync_at.present?
       "in:anywhere after:#{latest_sync_at.strftime('%Y/%m/%d')}"
     else

--- a/spec/lib/ingestors/google/gmail_spec.rb
+++ b/spec/lib/ingestors/google/gmail_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Ingestors::Google::Gmail do
     )
   end
 
-  let(:sync_log) { create(:sync_log, task_name: 'Sync::GmailMessagesJob', user:) }
+  let(:sync_log) { create(:sync_log, task_name: :gmail, user:) }
   let(:message_content) { '<p>Test Body</p>' }
 
   before do


### PR DESCRIPTION

Task name was changed so that it was decoupled from the implementation class. Must have missed these when I made that change.
